### PR TITLE
Nowmal service for multiple servers

### DIFF
--- a/factorio@.service
+++ b/factorio@.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Factorio server %i
+Requires=network-online.target
+
+[Service]
+WorkingDirectory=/opt/factorio%i/FactoCord/
+User=factorio%i
+Type=forking
+
+ExecStart=/usr/bin/tmux new-session -s factorio%i -d '/opt/factorio%i/FactoCord/FactoCord'
+
+ExecStop=/usr/bin/tmux send-keys -t factorio%i 'Server shutdown in 10 seconds! Please save map!' Enter
+ExecStop=/bin/sleep 10
+ExecStop=/usr/bin/tmux send-keys -t factorio%i '/quit' Enter
+ExecStop=/bin/sleep 10
+ExecStop=/usr/bin/tmux kill-session -t factorio%i
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Uses tmux as console manager.
Working now on Projects74 Discord server.
Install:
cp factorio@.service /etc/systemd/system/
Usage:
service factorioXXXXX.service start|stop|status
, where XXXXX is server number